### PR TITLE
add matrix destruction to test case, debug double free error, adding …

### DIFF
--- a/src/lasSparse.cc
+++ b/src/lasSparse.cc
@@ -43,7 +43,7 @@ namespace las
             if(((*x_csr)(xrw,inr) >= 0 && (*y_csr)(inr,ycl) >= 0))
               bld.add(xrw,ycl);
       Sparsity * z_csr = bld.finalize();
-      (*z) = createCSRMatrix(z_csr);
+      (*z) = createCSRMatrix(z_csr,true);
       csrMat * cz = getCSRMat(*z);
       for(int xrw = 0; xrw < x_nr; ++xrw)
         for(int ycl = 0; ycl < y_nc; ++ycl)

--- a/src/lasSparse_impl.h
+++ b/src/lasSparse_impl.h
@@ -13,17 +13,27 @@ namespace las
   {
     scalar * vls; // nnz +2 (dumy write, 0.0 read)
     CSR * csr;
+    bool own;
   public:
-    csrMat(CSR * c)
+    csrMat(CSR * c, bool o = false)
       : vls(nullptr)
       , csr(c)
+      , own(o)
     {
-      alloc<Malloc>((void**)&vls,sizeof(scalar) * (c->getNumNonzero() + 2));
+      //alloc<Malloc>((void**)&vls,sizeof(scalar) * (c->getNumNonzero() + 2));
+      vls = new scalar[c->getNumNonzero()+2];
       memset(&vls[0],0,sizeof(scalar)*(csr->getNumNonzero() + 2));
     }
     ~csrMat()
     {
-      dealloc<Malloc>((void**)&vls);
+      delete [] vls;
+      vls = nullptr;
+      if(own)
+      {
+        delete csr;
+        csr = nullptr;
+       }
+      //dealloc<Malloc>((void**)&vls);
     }
     scalar & operator()(int rr, int cc)
     {
@@ -49,9 +59,9 @@ namespace las
   {
     return reinterpret_cast<csrMat*>(m);
   }
-  LAS_INLINE Mat * createCSRMatrix(Sparsity * csr)
+  LAS_INLINE Mat * createCSRMatrix(Sparsity * csr, bool o = false)
   {
-    return reinterpret_cast<Mat*>(new csrMat(reinterpret_cast<CSR*>(csr)));
+    return reinterpret_cast<Mat*>(new csrMat(reinterpret_cast<CSR*>(csr),o));
   }
   LAS_INLINE void destroyCSRMatrix(Mat * m)
   {

--- a/test/csr.cc
+++ b/test/csr.cc
@@ -31,6 +31,9 @@ int main(int ac,char * av[])
   for(int idx = 0; idx < 9; ++idx)
     assert(rst_arr[idx] == col[idx]);
   delete [] rst_arr;
+  mat_fct->destroy(rst);
+  mat_fct->destroy(eye_mat);
+  mat_fct->destroy(col_mat);
   double empty_row[] = {1.0, 0.0, 1.0,
                         0.0, 0.0, 0.0,
                         1.0, 0.0, 1.0};
@@ -51,6 +54,9 @@ int main(int ac,char * av[])
   for(int idx = 0; idx < 9; idx++)
     assert(rst2_arr[idx] == expect[idx]);
   delete [] rst2_arr;
+  mat_fct->destroy(rst2);
+  mat_fct->destroy(row_col_mat);
+  mat_fct->destroy(empty_row_mat);
   MPI_Finalize();
   return 0;
 }


### PR DESCRIPTION
…in ability to specify sparsity pattern ownership in the csr constructor