### PR TITLE
Build libraries as static libraries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.vs
 /CppProperties.json
 /CMakeSettings.json
-build/
+build*/
 src/lasComm.h
 src/lasConfig.h
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0 FATAL_ERROR) # version 3.8 adds cuda as a lan
 project(las)
 set(LAS_MAJOR_VERSION 0)
 set(LAS_MINOR_VERSION 1)
-set(LAS_PATCH_VERSION 28)
+set(LAS_PATCH_VERSION 29)
 set(LAS_VERSION ${LAS_MAJOR_VERSION}.${LAS_MINOR_VERSION}.${LAS_PATCH_VERSION})
 enable_language(CXX)
 enable_language(C)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -25,7 +25,7 @@ if(PETSC_FOUND)
   set(include_dirs ${include_dirs} ${PETSC_INCLUDE_DIRS})
 endif()
 
-add_library(las_core ${las_core_sources})
+add_library(las_core STATIC ${las_core_sources})
 if(${CMAKE_VERSION} VERSION_GREATER "3.8.2")
   target_compile_features(las_core PUBLIC cxx_std_11)
 endif()

--- a/sparskit/CMakeLists.txt
+++ b/sparskit/CMakeLists.txt
@@ -10,5 +10,5 @@ set(sparskit_source
   src/tql2.f
   src/tred2EISPACK.f
   src/utils.f )
-add_library(sparskit ${sparskit_source})
+add_library(sparskit STATIC ${sparskit_source})
 install(TARGETS sparskit EXPORT lasConfig DESTINATION lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,7 +86,7 @@ endif()
 configure_file(lasConfig.h.in "${CMAKE_CURRENT_SOURCE_DIR}/lasConfig.h" @ONLY)
 set(las_headers ${las_headers} ${las_install} lasConfig.h)
 
-add_library(las ${las_sources})
+add_library(las STATIC ${las_sources})
 if(${CMAKE_VERSION} VERSION_GREATER "3.8.2")
   target_compile_features(las PUBLIC cxx_std_11)
 endif()
@@ -121,7 +121,7 @@ function(add_backend backend headers libraries)
   to_include(capi_header capi_header_include)
   configure_file(capi/las_capi.cc ${capi_source})
   set(capi_lib las_capi_${backend})
-  add_library(${capi_lib}
+  add_library(${capi_lib} STATIC
     ${CMAKE_CURRENT_BINARY_DIR}/capi/las_capi_${backend}.h
     ${CMAKE_CURRENT_BINARY_DIR}/capi/las_capi_${backend}.cc
     ${headers})


### PR DESCRIPTION
fixes #47. On the RHEL7 machines the libraries default to building as
shared libs. This commit builds all libraries as static.