### PR TITLE
Grow sparskit buffers if they are two small

### DIFF
--- a/src/lasSparskitExterns.cc
+++ b/src/lasSparskitExterns.cc
@@ -1,4 +1,5 @@
 #include "lasSparskitExterns.h"
+#include <cassert>
 #ifdef BGQ
 void ilut_(int *n,double a[],int ja[],int ia[],int *lfil,double *droptol,double *alu,int *jlu,int *ju,int *iwk,double *w,int *jw,int *ierr)
 {
@@ -37,12 +38,32 @@ namespace las
       , matrix(heuristic_length)
   {
   }
+  // note that we use the cols buffer and matrix buffer for items that will be returned
+  // in MSR format which means the "correct" heuristic length is NNZ+NDZ+1 where NDZ
+  // is the number of diagonal zeros
+  SparskitBuffers::SparskitBuffers(int num_dofs, int num_nonzero, int num_diag_zeros)
+      : heuristic_length(num_nonzero+num_diag_zeros+1)
+      , int_work_array(2 * num_dofs)
+      , rows(num_dofs)
+      , cols(heuristic_length)
+      , double_work_array(num_dofs)
+      , matrix(heuristic_length)
+  {
+  }
   void SparskitBuffers::zero()
   {
     int_work_array.assign(int_work_array.size(),0.0);
     rows.assign(rows.size(),0.0);
-    cols.assign(heuristic_length,0.0);
+    cols.assign(cols.size(),0.0);
     double_work_array.assign(double_work_array.size(),0.0);
-    matrix.assign(heuristic_length,0.0);
+    matrix.assign(matrix.size(),0.0);
+  }
+  void SparskitBuffers::resizeMatrixBuffer(int newSize) {
+    assert((newSize-matrixLength()) > 0);
+    heuristic_length = newSize;
+    matrix.resize(heuristic_length);
+    cols.resize(heuristic_length);
+    assert(cols.size() == heuristic_length);
+    assert(matrix.size() == heuristic_length);
   }
 };

--- a/src/lasSparskitExterns.h
+++ b/src/lasSparskitExterns.h
@@ -37,13 +37,15 @@ namespace las
   public:
     SparskitBuffers(int num_dofs);
     SparskitBuffers(int num_dofs, int num_nonzero);
+    SparskitBuffers(int num_dofs, int num_nonzero, int num_diag_zeros);
     void zero();
-    int matrixLength() {return heuristic_length;}
+    int matrixLength() {return matrix.size();}
     int * intWorkBuffer() {return &int_work_array[0];}
     int * rowsBuffer() {return &rows[0];}
     int * colsBuffer() {return &cols[0];}
     double * doubleWorkBuffer() {return &double_work_array[0];}
     double * matrixBuffer() {return &matrix[0];}
+    void resizeMatrixBuffer(int newSize);
   };
 }
 #endif


### PR DESCRIPTION
This allows us to not way over allocate memory which is detrimental to
program speed and was making it difficult to run on BGQ with dense
networks.